### PR TITLE
- changed diff-tool build path to OPENMODELICAHOME

### DIFF
--- a/difftool/Makefile
+++ b/difftool/Makefile
@@ -3,7 +3,7 @@ CC = gcc
 EXT=".exe"
 endif
 
-OMBUILDDIR=../../build
+OMBUILDDIR=$(OPENMODELICAHOME)
 
 $(OMBUILDDIR)/bin/omc-diff$(EXT): lex.yy.o $(OMBUILDDIR)/bin
 	$(CC) -o $@ lex.yy.o


### PR DESCRIPTION
Can we change the relative path of the diff-tool creation to the OPENMODELICAHOME-Environment variable? Because if somebody does not use the super project, the "../../build"-path is not correct. 