### PR TITLE
State machine tests adapted to OMCompiler#123

### DIFF
--- a/flattening/modelica/statemachines/ConferenceTut1.mo
+++ b/flattening/modelica/statemachines/ConferenceTut1.mo
@@ -34,13 +34,24 @@ end ConferenceTut1;
 // Result:
 // class ConferenceTut1
 //   Integer i(start = 0);
-//   output Integer state1.i = i;
-//   output Integer state2.i = i;
+// stateMachine state1
+//   state state1
+//       output Integer state1.i;
+//     equation
+//       state1.i = 2 + previous(i);
+//   end state1;
+// 
+//   state state2
+//       output Integer state2.i;
+//     equation
+//       state2.i = -1 + previous(i);
+//   end state2;
+//   equation
+//     initialState(state1);
+//     transition(state1, state2, i > 10, false, true, false, 1);
+//     transition(state2, state1, i < 1, false, true, false, 1);
+// end state1;
 // equation
-//   state1.i = 2 + previous(state1.i);
-//   state2.i = -1 + previous(state2.i);
-//   initialState(state1);
-//   transition(state1, state2, i > 10, false, true, false, 1);
-//   transition(state2, state1, i < 1, false, true, false, 1);
+//   i = if activeState(state1) then state1.i else if activeState(state2) then state2.i else previous(i);
 // end ConferenceTut1;
 // endResult

--- a/flattening/modelica/statemachines/HierarchicalAndParallelStateMachine.mo
+++ b/flattening/modelica/statemachines/HierarchicalAndParallelStateMachine.mo
@@ -84,32 +84,73 @@ end HierarchicalAndParallelStateMachine;
 // Result:
 // class HierarchicalAndParallelStateMachine "Example from the MLS 3.3, Section 17.3.7"
 //   Integer v(start = 0);
-//   Integer state1.count(start = 0);
-//   output Integer state1.v = v;
-//   output Integer state1.stateA.v = state1.v;
-//   output Integer state1.stateB.v = state1.v;
-//   output Integer state1.stateC.count = state1.count;
-//   Integer state1.stateX.i(start = 0);
-//   Integer state1.stateX.w;
-//   Integer state1.stateY.j(start = 0);
-//   output Integer state2.v = v;
+// stateMachine state1
+//   state state1
+//       Integer state1.count(start = 0);
+//       output Integer state1.v;
+//     stateMachine state1.stateX
+//       state state1.stateX
+//           Integer state1.stateX.i(start = 0);
+//           Integer state1.stateX.w;
+//         equation
+//           state1.stateX.i = 1 + previous(state1.stateX.i);
+//           state1.stateX.w = state1.v;
+//       end state1.stateX;
+// 
+//       state state1.stateY
+//           Integer state1.stateY.j(start = 0);
+//         equation
+//           state1.stateY.j = 1 + previous(state1.stateY.j);
+//       end state1.stateY;
+//       equation
+//         transition(state1.stateX, state1.stateY, state1.stateX.i > 20, false, true, false, 1);
+//         initialState(state1.stateX);
+//     end state1.stateX;
+// 
+//     stateMachine state1.stateA
+//       state state1.stateA
+//           output Integer state1.stateA.v;
+//         equation
+//           state1.stateA.v = 2 + previous(v);
+//       end state1.stateA;
+// 
+//       state state1.stateB
+//           output Integer state1.stateB.v;
+//         equation
+//           state1.stateB.v = -1 + previous(v);
+//       end state1.stateB;
+// 
+//       state state1.stateC
+//           output Integer state1.stateC.count;
+//         equation
+//           state1.stateC.count = 1 + previous(state1.count);
+//       end state1.stateC;
+// 
+//       state state1.stateD
+//       end state1.stateD;
+//       equation
+//         initialState(state1.stateA);
+//         transition(state1.stateA, state1.stateB, state1.v >= 6, false, true, false, 1);
+//         transition(state1.stateB, state1.stateC, state1.v == 0, false, true, false, 1);
+//         transition(state1.stateC, state1.stateA, true, false, true, false, 2);
+//         transition(state1.stateC, state1.stateD, state1.count >= 2, false, true, false, 1);
+//     end state1.stateA;
+//     equation
+//       state1.v = if activeState(state1.stateA) then state1.stateA.v else if activeState(state1.stateB) then state1.stateB.v else previous(v);
+//       state1.count = if activeState(state1.stateC) then state1.stateC.count else previous(state1.count);
+//   end state1;
+// 
+//   state state2
+//       output Integer state2.v;
+//     equation
+//       state2.v = 5 + previous(v);
+//   end state2;
+//   equation
+//     initialState(state1);
+//     transition(state1, state2, activeState(state1.stateD) and activeState(state1.stateY), false, true, false, 1);
+//     transition(state2, state1, v >= 20, false, true, false, 1);
+// end state1;
 // equation
-//   state1.stateA.v = 2 + previous(state1.stateA.v);
-//   state1.stateB.v = -1 + previous(state1.stateB.v);
-//   state1.stateC.count = 1 + previous(state1.stateC.count);
-//   state1.stateX.i = 1 + previous(state1.stateX.i);
-//   state1.stateX.w = state1.v;
-//   state1.stateY.j = 1 + previous(state1.stateY.j);
-//   transition(state1.stateX, state1.stateY, state1.stateX.i > 20, false, true, false, 1);
-//   initialState(state1.stateX);
-//   initialState(state1.stateA);
-//   transition(state1.stateA, state1.stateB, state1.v >= 6, false, true, false, 1);
-//   transition(state1.stateB, state1.stateC, state1.v == 0, false, true, false, 1);
-//   transition(state1.stateC, state1.stateA, true, false, true, false, 2);
-//   transition(state1.stateC, state1.stateD, state1.count >= 2, false, true, false, 1);
-//   state2.v = 5 + previous(state2.v);
-//   initialState(state1);
-//   transition(state1, state2, activeState(state1.stateD) and activeState(state1.stateY), false, true, false, 1);
-//   transition(state2, state1, v >= 20, false, true, false, 1);
+//   v = if activeState(state1) then state1.v else if activeState(state2) then state2.v else previous(v);
 // end HierarchicalAndParallelStateMachine;
 // endResult

--- a/flattening/modelica/statemachines/InitialState2Test.mo
+++ b/flattening/modelica/statemachines/InitialState2Test.mo
@@ -1,6 +1,6 @@
 // name: InitialState2Test
 // keywords: state machines features
-// status: correct
+// status: wrong
 
 model InitialState2Test
   block AState
@@ -11,8 +11,4 @@ equation
 end InitialState2Test;
 
 // Result:
-// class InitialState2Test
-// equation
-//   initialState(aState);
-// end InitialState2Test;
 // endResult

--- a/flattening/modelica/statemachines/InitialStateTest.mo
+++ b/flattening/modelica/statemachines/InitialStateTest.mo
@@ -1,6 +1,6 @@
 // name: InitialStateTest
 // keywords: state machines features
-// status: correct
+// status: wrong
 
 model InitialStateTest
   block AState
@@ -12,9 +12,4 @@ equation
 end InitialStateTest;
 
 // Result:
-// class InitialStateTest
-//   output Real aState.dummy;
-// equation
-//   initialState(aState);
-// end InitialStateTest;
 // endResult

--- a/flattening/modelica/statemachines/Makefile
+++ b/flattening/modelica/statemachines/Makefile
@@ -3,16 +3,16 @@ TEST = ../../../rtest -v
 TESTFILES = \
 TicksInStateTest.mo \
 TimeInStateTest.mo \
-InitialStateTest.mo \
+HierarchicalAndParallelStateMachine.mo \
 ActiveStateTest.mo \
-TransitionTest.mo \
-InitialState2Test.mo \
 ConferenceTut1.mo \
 
 # test that currently fail. Move up when fixed. 
 # Run make failingtest
 FAILINGTESTFILES = \
-HierarchicalAndParallelStateMachine.mo \
+InitialStateTest.mo \
+InitialState2Test.mo \
+TransitionTest.mo \
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/flattening/modelica/statemachines/TransitionTest.mo
+++ b/flattening/modelica/statemachines/TransitionTest.mo
@@ -1,6 +1,6 @@
 // name: TransitionTest
 // keywords: state machines features
-// status: correct
+// status: wrong
 
 model TransitionTest
   block AState
@@ -15,12 +15,4 @@ equation
 end TransitionTest;
 
 // Result:
-// class TransitionTest
-//   output Real aState1.dummy;
-//   output Real aState2.dummy;
-// equation
-//   transition(aState1, aState2, true, true, true, false, 1);
-//   transition(aState1, aState2, true, false, true, false, 1);
-//   transition(aState1, aState2, false, false, false, true, 10);
-// end TransitionTest;
 // endResult


### PR DESCRIPTION
Three tests are failing now and have been moved to FAILINGTESTFILES (seems to be an issue with having single state state machines), the rather elaborate MLS example however works with the new prototype.