### PR TITLE
Add fully specified initial conditions to modelicaML tests

### DIFF
--- a/openmodelica/modelicaML/BouncingBallExample/Ball.mo
+++ b/openmodelica/modelicaML/BouncingBallExample/Ball.mo
@@ -6,15 +6,15 @@ model Ball
   annotation(Diagram(coordinateSystem(extent={{-148.5,-105.0},{148.5,105.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10})), Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10}), graphics={Rectangle(visible=true, origin={0.0,65.0}, fillColor={255,255,255}, fillPattern=FillPattern.Solid, lineThickness=1, extent={{-100.0,-35.0},{100.0,35.0}}),Rectangle(visible=true, origin={0.0,-35.0}, fillColor={255,255,255}, fillPattern=FillPattern.Solid, lineThickness=1, extent={{-100.0,-65.0},{100.0,65.0}}),Text(visible=true, origin={0.0,52.0578}, fillPattern=FillPattern.Solid, extent={{-96.311,-15.0969},{96.311,15.0969}}, textString="Ball", fontName="Arial"),Text(visible=true, origin={0.0,83.1521}, fillPattern=FillPattern.Solid, extent={{-90.0,-11.3192},{90.0,11.3192}}, textString="«model»", fontName="Arial"),Text(visible=true, origin={0.3349,-37.1756}, fillPattern=FillPattern.Solid, extent={{-97.7954,-59.2801},{97.7954,59.2801}}, textString="M", fontName="Arial")}));
   parameter Real g=9.81;
   parameter Real c= 0.90;
-  Real height(start=0);
-  Real v(start=10);
+  Real height(start=0, fixed=true);
+  Real v(start=10, fixed=true);
   record Ball_StateMachine_StateMachine_0
   annotation(Diagram(coordinateSystem(extent={{-148.5,-105.0},{148.5,105.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10})), Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10}), graphics={Rectangle(visible=true, origin={-6.722,3.6841}, lineColor={0,85,127}, fillColor={85,170,255}, fillPattern=FillPattern.Solid, lineThickness=10, extent={{-75.0,-50.0},{75.0,50.0}}, radius=40),Rectangle(visible=true, origin={70.0,2.6556}, lineColor={85,170,255}, fillColor={0,85,127}, fillPattern=FillPattern.Solid, lineThickness=4, extent={{-26.8908,-25.0},{26.8908,25.0}})}));
     // lib properties STATE MACHINE
-      Boolean active; // indicates if the state is active.
-      Real timeAtActivation; // time when the state is entered.
+      Boolean active(fixed=true); // indicates if the state is active.
+      Real timeAtActivation(fixed=true); // time when the state is entered.
       Real stime; // stime means "state time". It is is a local timer. It starts when the state is entered and is equal to zero if the state is not active.
-      Boolean selfTransitionActivated;
+      Boolean selfTransitionActivated(fixed=true);
     Boolean startBehaviour;
     // REGIONS instantiation
     StateMachine_0_Region_0 Region_0;
@@ -37,10 +37,10 @@ model Ball
     record SimpleState
       annotation(Diagram(coordinateSystem(extent={{-148.5,-105.0},{148.5,105.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10})), Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10}), graphics={Rectangle(visible=true, origin={-0.0,-0.1675}, lineColor={0,85,127}, fillColor={104,182,221}, fillPattern=FillPattern.HorizontalCylinder, lineThickness=10, extent={{-64.6031,-34.6638},{64.6031,34.6638}}, radius=40)}));
       // lib properties SIMPLE STATE
-        Boolean active; // indicates if the state is active.
-        Real timeAtActivation; // time when the state is entered.
+        Boolean active(fixed=true); // indicates if the state is active.
+        Real timeAtActivation(fixed=true); // time when the state is entered.
         Real stime; // stime means "state time". It is is a local timer. It starts when the state is entered and is equal to zero if the state is not active.
-        Boolean selfTransitionActivated;
+        Boolean selfTransitionActivated(fixed=true);
     end SimpleState;
 
       // library: INITIAL STATE
@@ -48,17 +48,17 @@ model Ball
       annotation(Diagram(coordinateSystem(extent={{-148.5,-105.0},{148.5,105.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10})), Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10}), graphics={Rectangle(visible=true, origin={-0.0,0.0}, lineColor={0,85,127}, fillColor={104,182,221}, fillPattern=FillPattern.HorizontalCylinder, lineThickness=10, extent={{-34.8134,-34.6638},{34.8134,34.6638}}, radius=40)}));
       // lib properties INITIAL STATE
         Boolean active; // indicates if the state is active.
-        Real timeAtActivation; // time when the state is entered.
+        Real timeAtActivation(fixed=true); // time when the state is entered.
         Real stime; // stime means "state time". It is is a local timer. It starts when the state is entered and is equal to zero if the state is not active.
-        Boolean selfTransitionActivated;
+        Boolean selfTransitionActivated(fixed=true);
     end InitialState;
 
         // library: FINAL STATE
     record FinalState
       annotation(Diagram(coordinateSystem(extent={{-148.5,-105.0},{148.5,105.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10})), Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10}), graphics={Rectangle(visible=true, origin={0.0,0.0}, lineColor={0,85,127}, fillColor={255,255,255}, fillPattern=FillPattern.HorizontalCylinder, lineThickness=10, extent={{-34.8134,-34.6638},{34.8134,34.6638}}, radius=40),Rectangle(visible=true, origin={0.0,0.0}, fillPattern=FillPattern.HorizontalCylinder, lineThickness=10, extent={{-17.2767,-17.2024},{17.2767,17.2024}}, radius=40)}));
       // lib properties FINAL STATE
-        Boolean active; // indicates if the state is active.
-        Real timeAtActivation; // time when the state is entered.
+        Boolean active(fixed=true); // indicates if the state is active.
+        Real timeAtActivation(fixed=true); // time when the state is entered.
         Real stime; // stime means "state time". It is is a local timer. It starts when the state is entered and is equal to zero if the state is not active.
         Boolean selfTransitionActivated;
     end FinalState;

--- a/openmodelica/modelicaML/ModelicaMLModel/Design/SystemModel1.mo
+++ b/openmodelica/modelicaML/ModelicaMLModel/Design/SystemModel1.mo
@@ -8,10 +8,10 @@ model SystemModel1
   record SystemModel1_StateMachine_StateMachine0
   annotation(Diagram(coordinateSystem(extent={{-148.5,-105.0},{148.5,105.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10})), Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10}), graphics={Rectangle(visible=true, origin={-6.722,3.6841}, lineColor={0,85,127}, fillColor={85,170,255}, fillPattern=FillPattern.Solid, lineThickness=10, extent={{-75.0,-50.0},{75.0,50.0}}, radius=40),Rectangle(visible=true, origin={70.0,2.6556}, lineColor={85,170,255}, fillColor={0,85,127}, fillPattern=FillPattern.Solid, lineThickness=4, extent={{-26.8908,-25.0},{26.8908,25.0}})}));
     // lib properties STATE MACHINE
-      Boolean active; // indicates if the state is active.
-      Real timeAtActivation; // time when the state is entered.
+      Boolean active(fixed=true); // indicates if the state is active.
+      Real timeAtActivation(fixed=true); // time when the state is entered.
       Real stime; // stime means "state time". It is is a local timer. It starts when the state is entered and is equal to zero if the state is not active.
-      Boolean selfTransitionActivated;
+      Boolean selfTransitionActivated(fixed=true);
     Boolean startBehaviour;
     // REGIONS instantiation
     StateMachine0_Region0 Region0;
@@ -33,10 +33,10 @@ model SystemModel1
     record SimpleState
       annotation(Diagram(coordinateSystem(extent={{-148.5,-105.0},{148.5,105.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10})), Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10}), graphics={Rectangle(visible=true, origin={-0.0,-0.1675}, lineColor={0,85,127}, fillColor={104,182,221}, fillPattern=FillPattern.HorizontalCylinder, lineThickness=10, extent={{-64.6031,-34.6638},{64.6031,34.6638}}, radius=40)}));
       // lib properties SIMPLE STATE
-        Boolean active; // indicates if the state is active.
-        Real timeAtActivation; // time when the state is entered.
+        Boolean active(fixed=true); // indicates if the state is active.
+        Real timeAtActivation(fixed=true); // time when the state is entered.
         Real stime; // stime means "state time". It is is a local timer. It starts when the state is entered and is equal to zero if the state is not active.
-        Boolean selfTransitionActivated;
+        Boolean selfTransitionActivated(fixed=true);
     end SimpleState;
 
       // library: INITIAL STATE
@@ -44,9 +44,9 @@ model SystemModel1
       annotation(Diagram(coordinateSystem(extent={{-148.5,-105.0},{148.5,105.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10})), Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10}), graphics={Rectangle(visible=true, origin={-0.0,0.0}, lineColor={0,85,127}, fillColor={104,182,221}, fillPattern=FillPattern.HorizontalCylinder, lineThickness=10, extent={{-34.8134,-34.6638},{34.8134,34.6638}}, radius=40)}));
       // lib properties INITIAL STATE
         Boolean active; // indicates if the state is active.
-        Real timeAtActivation; // time when the state is entered.
+        Real timeAtActivation(fixed=true); // time when the state is entered.
         Real stime; // stime means "state time". It is is a local timer. It starts when the state is entered and is equal to zero if the state is not active.
-        Boolean selfTransitionActivated;
+        Boolean selfTransitionActivated(fixed=true);
     end InitialState;
 
         // library: FINAL STATE
@@ -54,9 +54,9 @@ model SystemModel1
       annotation(Diagram(coordinateSystem(extent={{-148.5,-105.0},{148.5,105.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10})), Icon(coordinateSystem(extent={{-100.0,-100.0},{100.0,100.0}}, preserveAspectRatio=true, initialScale=0.1, grid={10,10}), graphics={Rectangle(visible=true, origin={0.0,0.0}, lineColor={0,85,127}, fillColor={255,255,255}, fillPattern=FillPattern.HorizontalCylinder, lineThickness=10, extent={{-34.8134,-34.6638},{34.8134,34.6638}}, radius=40),Rectangle(visible=true, origin={0.0,0.0}, fillPattern=FillPattern.HorizontalCylinder, lineThickness=10, extent={{-17.2767,-17.2024},{17.2767,17.2024}}, radius=40)}));
       // lib properties FINAL STATE
         Boolean active; // indicates if the state is active.
-        Real timeAtActivation; // time when the state is entered.
+        Real timeAtActivation(fixed=true); // time when the state is entered.
         Real stime; // stime means "state time". It is is a local timer. It starts when the state is entered and is equal to zero if the state is not active.
-        Boolean selfTransitionActivated;
+        Boolean selfTransitionActivated(fixed=true);
     end FinalState;
   end SystemModel1_StateMachine_StateMachine0;
 

--- a/openmodelica/modelicaML/bouncingball.mos
+++ b/openmodelica/modelicaML/bouncingball.mos
@@ -5,8 +5,8 @@
 // 
 // ModelicaML: 1.3.6 Examples from 29.Nov 2010
 
-loadFile("./BouncingBallExample/package.mo");
-simulate(BouncingBallExample.Ball,stopTime=20,numberOfIntervals=2000);
+loadFile("./BouncingBallExample/package.mo"); getErrorString();
+simulate(BouncingBallExample.Ball,stopTime=20,numberOfIntervals=2000); getErrorString();
 
 val(height,0);
 val(height,1.02);
@@ -19,11 +19,13 @@ val(StateMachine_0.Region_0.Falling.active,20);
 
 // Result:
 // true
+// ""
 // record SimulationResult
 //     resultFile = "BouncingBallExample.Ball_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 20.0, numberOfIntervals = 2000, tolerance = 0.000001, method = 'dassl', fileNamePrefix = 'BouncingBallExample.Ball', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = ""
 // end SimulationResult;
+// ""
 // 0.00273783877491951
 // 5.108748949347676
 // 2.6034730761167073

--- a/openmodelica/modelicaML/testModelicaML.mos
+++ b/openmodelica/modelicaML/testModelicaML.mos
@@ -5,9 +5,8 @@
 // 
 // ModelicaML: Examples from 22.Jun 2011
 
-loadFile("./ModelicaMLModel/package.mo");
-getErrorString();
-simulate(ModelicaMLModel.Design.SystemModel1,stopTime=150);
+loadFile("./ModelicaMLModel/package.mo"); getErrorString();
+simulate(ModelicaMLModel.Design.SystemModel1,stopTime=150); getErrorString();
 
 val(realVar,0);
 val(realVar,20);
@@ -26,6 +25,7 @@ val(realVar,140);
 //     simulationOptions = "startTime = 0.0, stopTime = 150.0, numberOfIntervals = 500, tolerance = 0.000001, method = 'dassl', fileNamePrefix = 'ModelicaMLModel.Design.SystemModel1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = ""
 // end SimulationResult;
+// ""
 // 0.0
 // 0.0
 // 0.0


### PR DESCRIPTION
I am not sure what the purpose of the modelicaML examples is, but it’s probably not about testing underdetermined initialization problems. Therefore, this pull request provides fully specified initial conditions.
I guess that also the failing modelicaML examples would run successfully, if they had fully specified initial conditions.

@adrpo Please merge this pull request if you agree with the changes.