### PR TITLE
Replace deprecated pre-optimization flags

### DIFF
--- a/openmodelica/cruntime/optimization/basic/TFC6.mos
+++ b/openmodelica/cruntime/optimization/basic/TFC6.mos
@@ -36,7 +36,7 @@ end testFinalCon6;
 ");
 getErrorString();
 
-setCommandLineOptions("+maxSizeSolveLinearSystem=10 +d=addDerAliases");
+setCommandLineOptions("+maxSizeSolveLinearSystem=10 --preOptModules+=introduceDerAlias");
 getErrorString();
 optimize(testFinalCon6, numberOfIntervals=50, tolerance = 1e-08, stopTime = 5, simflags="-lv LOG_IPOPT_ERROR,LOG_LS -optimizerNP 3");
 getErrorString();

--- a/openmodelica/debugDumps/lateInline.mos
+++ b/openmodelica/debugDumps/lateInline.mos
@@ -21,7 +21,7 @@ model testOptdaedump
   Real y = exp(time^3) + x;
 end testOptdaedump;
 "); getErrorString();
-setCommandLineOptions("+cseCall");
+setCommandLineOptions("--postOptModules+=wrapFunctionCalls");
 setDebugFlags("optdaedump"); getErrorString();
 buildModel(testOptdaedump); getErrorString();
 
@@ -300,6 +300,18 @@ buildModel(testOptdaedump); getErrorString();
 // State Sets
 // ========================================
 //
+//
+// Incidence Matrix (row: equation)
+// ========================================
+// number of rows: 2
+// 1: 2
+// 2: 2 1
+//
+// Transposed Incidence Matrix (row: variable)
+// ========================================
+// number of rows: 2
+// 1: 2
+// 2: 2 1
 //
 // no matching
 //

--- a/simulation/libraries/3rdParty/ThermoPower/Bug2537.mos
+++ b/simulation/libraries/3rdParty/ThermoPower/Bug2537.mos
@@ -7,7 +7,7 @@
 //
 
 loadFile("Bug2537.mo"); getErrorString();
-setCommandLineOptions("+cseCall"); getErrorString();
+setCommandLineOptions("--postOptModules+=wrapFunctionCalls"); getErrorString();
 simulate(ThermoPower.Examples.CISE.CISESim120501); getErrorString();
 
 // Result:

--- a/simulation/libraries/3rdParty/siemens/testSolidComponentsJac.mos
+++ b/simulation/libraries/3rdParty/siemens/testSolidComponentsJac.mos
@@ -9,9 +9,8 @@
 loadModel(SiemensPower, {"2.1 beta"});getErrorString();
 
 // test jacobians
-setCommandLineOptions("+generateSymbolicJacobian");
-simulate(SiemensPower.Components.SolidComponents.Tests.wall_test, stopTime=25, method="dassl", simflags="-dasslJacobian=symbolical");
-getErrorString();
+setCommandLineOptions("--postOptModules+=generateSymbolicJacobian"); getErrorString();
+simulate(SiemensPower.Components.SolidComponents.Tests.wall_test, stopTime=25, method="dassl", simflags="-dasslJacobian=symbolical"); getErrorString();
 
 res := OpenModelica.Scripting.compareSimulationResults("SiemensPower.Components.SolidComponents.Tests.wall_test_res.mat",getEnvironmentVar("REFERENCEFILES")+"/SiemensPower/wall_test.mat","SiemensPower.Components.SolidComponents.Tests.wall_test_diff.csv",0.01,0.00001,
   { "heatInput.C1signal.y",
@@ -38,6 +37,7 @@ res := OpenModelica.Scripting.compareSimulationResults("SiemensPower.Components.
 // true
 // ""
 // true
+// ""
 // record SimulationResult
 //     resultFile = "SiemensPower.Components.SolidComponents.Tests.wall_test_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 25.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'SiemensPower.Components.SolidComponents.Tests.wall_test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-dasslJacobian=symbolical'",

--- a/simulation/libraries/msl32/Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation-addDerAlias.mos
+++ b/simulation/libraries/msl32/Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation-addDerAlias.mos
@@ -13,7 +13,7 @@
 runScript("../common/ModelTestingDefaults.mos"); getErrorString();
 
 setTearingMethod("omcTearing");
-setCommandLineOptions("+d=addDerAliases");
+setCommandLineOptions("--preOptModules+=introduceDerAlias");
 modelTestingType := OpenModelicaModelTesting.Kind.VerifiedSimulation;
 modelName := $TypeName(Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation);
 compareVars :=

--- a/simulation/modelica/commonSubExp/cse1.mos
+++ b/simulation/modelica/commonSubExp/cse1.mos
@@ -28,7 +28,7 @@ end Tearing15;
 
 setDebugFlags("dumpCSE"); getErrorString();
 setTearingMethod("cellier"); getErrorString();
-setCommandLineOptions("+tearingHeuristic=MC1 +cseCall +cseBinary"); getErrorString();
+setCommandLineOptions("+tearingHeuristic=MC1 --postOptModules+=wrapFunctionCalls,cseBinary"); getErrorString();
 simulate(Tearing15); getErrorString();
 
 // Result:

--- a/simulation/modelica/commonSubExp/cse2.mos
+++ b/simulation/modelica/commonSubExp/cse2.mos
@@ -34,9 +34,9 @@ end Tearing3;
 
 //test the CSE of binary terms with introducing cse variables
 
-setDebugFlags("dumpCSE,disableComSubExp"); getErrorString();
+setDebugFlags("dumpCSE"); getErrorString();
 setTearingMethod("cellier"); getErrorString();
-setCommandLineOptions("+tearingHeuristic=MC1 +cseCall +cseBinary"); getErrorString();
+setCommandLineOptions("+tearingHeuristic=MC1 +cseCall +cseBinary --preOptModules-=comSubExp"); getErrorString();
 simulate(Tearing3); getErrorString();
 
 // Result:

--- a/simulation/modelica/commonSubExp/cse2.mos
+++ b/simulation/modelica/commonSubExp/cse2.mos
@@ -36,7 +36,7 @@ end Tearing3;
 
 setDebugFlags("dumpCSE"); getErrorString();
 setTearingMethod("cellier"); getErrorString();
-setCommandLineOptions("+tearingHeuristic=MC1 +cseCall +cseBinary --preOptModules-=comSubExp"); getErrorString();
+setCommandLineOptions("+tearingHeuristic=MC1 --postOptModules+=wrapFunctionCalls,cseBinary --preOptModules-=comSubExp"); getErrorString();
 simulate(Tearing3); getErrorString();
 
 // Result:

--- a/simulation/modelica/commonSubExp/cse3.mos
+++ b/simulation/modelica/commonSubExp/cse3.mos
@@ -27,7 +27,7 @@ end Tearing15;
 
 setDebugFlags("dumpCSE"); getErrorString();
 setTearingMethod("cellier"); getErrorString();
-setCommandLineOptions("+tearingHeuristic=MC1 +cseEachCall +cseBinary"); getErrorString();
+setCommandLineOptions("+tearingHeuristic=MC1 --postOptModules+=wrapFunctionCalls,cseBinary"); getErrorString();
 simulate(Tearing15); getErrorString();
 
 // Result:

--- a/simulation/modelica/commonSubExp/cseFunctionCall.mos
+++ b/simulation/modelica/commonSubExp/cseFunctionCall.mos
@@ -179,7 +179,7 @@ end CSE;
 "); getErrorString();
 
 setDebugFlags("dumpCSE"); getErrorString();
-setCommandLineOptions("+cseCall"); getErrorString();
+setCommandLineOptions("--postOptModules+=wrapFunctionCalls"); getErrorString();
 
 simulate(CSE.FunctionCallTest1); getErrorString();
 simulate(CSE.FunctionCallTest2); getErrorString();

--- a/simulation/modelica/others/ComplexFun.mos
+++ b/simulation/modelica/others/ComplexFun.mos
@@ -10,9 +10,9 @@ val(x,{0.0,0.1,0.2,0.7,1.0});
 simulate(problem2); getErrorString();
 
 val(y,{0.0,0.1,0.2,0.7,1.0});
- val(z,{0.0,0.1,0.2,0.7,1.0});
+val(z,{0.0,0.1,0.2,0.7,1.0});
 
-setCommandLineOptions("+cseEachCall"); getErrorString();
+setCommandLineOptions("--postOptModules+=wrapFunctionCalls"); getErrorString();
 simulate(problem1); getErrorString();
 
 val(x,{0.0,0.1,0.2,0.7,1.0}); getErrorString();
@@ -22,14 +22,14 @@ simulate(problem2); getErrorString();
 val(y,{0.0,0.1,0.2,0.7,1.0});
 val(z,{0.0,0.1,0.2,0.7,1.0});
 
-setCommandLineOptions("+d=disableSimplifyComplexFunction +cseEachCall=false"); getErrorString();
+setCommandLineOptions("--postOptModules-=wrapFunctionCalls,simplifyComplexFunction --initOptModules-=simplifyComplexFunction"); getErrorString();
 simulate(problem1); getErrorString();
 
 val(x,{0.0,0.1,0.2,0.7,1.0});
 
 simulate(problem2); getErrorString() == "";
 
-setCommandLineOptions("+d=disableSimplifyComplexFunction +cseEachCall"); getErrorString();
+setCommandLineOptions("--postOptModules+=wrapFunctionCalls"); getErrorString();
 simulate(problem1); getErrorString() == "";
 
 simulate(problem2); getErrorString() == "";

--- a/simulation/modelica/others/EngineV6_evalParams.mos
+++ b/simulation/modelica/others/EngineV6_evalParams.mos
@@ -4,7 +4,7 @@
 //
 loadModel(Modelica,{"3.2.1"});
 loadFile("EngineV6_output.mo");getErrorString();
-setDebugFlags("evalAllParams"); getErrorString();
+setCommandLineOptions("--preOptModules+=evaluateAllParameters"); getErrorString();
 simulate(EngineV6_output); getErrorString();
 
 val(crankshaftSpeed,1.0); getErrorString();

--- a/simulation/modelica/qss/qss_example9.mos
+++ b/simulation/modelica/qss/qss_example9.mos
@@ -12,7 +12,7 @@ package qssTests
 end qssTests;
 "); getErrorString();
 
-setCommandLineOptions("+addTimeAsState"); getErrorString();
+setCommandLineOptions("--postOptModules+=addTimeAsState"); getErrorString();
 simulate(qssTests.example9, method="qss"); getErrorString();
 val(x, {0.0, 1.0}); getErrorString();
 

--- a/simulation/modelica/resolveLoops/ElectricalCircuit1.mos
+++ b/simulation/modelica/resolveLoops/ElectricalCircuit1.mos
@@ -6,7 +6,8 @@
 loadModel(Modelica, {"3.2.1"}); getErrorString();
 
 loadFile("ElectricalCircuit1.mo"); getErrorString();
-setDebugFlags("backenddaeinfo,stateselection,resolveLoops"); getErrorString();
+setDebugFlags("backenddaeinfo,stateselection"); getErrorString();
+setCommandLineOptions("--preOptModules+=resolveLoops"); getErrorString();
 simulate(ElectricalCircuit1); getErrorString();
 
 res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit1_res.mat",
@@ -19,6 +20,8 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit1_res.m
   "C3.i",
   "C3.v"});
 // Result:
+// true
+// ""
 // true
 // ""
 // true

--- a/simulation/modelica/resolveLoops/ElectricalCircuit2.mos
+++ b/simulation/modelica/resolveLoops/ElectricalCircuit2.mos
@@ -6,7 +6,8 @@
 loadModel(Modelica, {"3.2.1"}); getErrorString();
 
 loadFile("ElectricalCircuit2.mo"); getErrorString();
-setDebugFlags("backenddaeinfo,resolveLoops,stateselection"); getErrorString();
+setDebugFlags("backenddaeinfo,stateselection"); getErrorString();
+setCommandLineOptions("--preOptModules+=resolveLoops"); getErrorString();
 simulate(ElectricalCircuit2); getErrorString();
 
 res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit2_res.mat",
@@ -21,6 +22,8 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit2_res.m
    "inductor1.v",
    "inductor1.i"});
 // Result:
+// true
+// ""
 // true
 // ""
 // true

--- a/simulation/modelica/resolveLoops/ElectricalCircuit3.mos
+++ b/simulation/modelica/resolveLoops/ElectricalCircuit3.mos
@@ -6,7 +6,8 @@
 loadModel(Modelica, {"3.2.1"}); getErrorString();
 
 loadFile("ElectricalCircuit3.mo"); getErrorString();
-setDebugFlags("resolveLoops,backenddaeinfo,stateselection"); getErrorString();
+setDebugFlags("backenddaeinfo,stateselection"); getErrorString();
+setCommandLineOptions("--preOptModules+=resolveLoops"); getErrorString();
 simulate(ElectricalCircuit3); getErrorString();
 res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit3_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/resolveLoops/ElectricalCircuit3.mat",
@@ -24,6 +25,8 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit3_res.m
    "capacitor1.v",
    "capacitor1.i"});
 // Result:
+// true
+// ""
 // true
 // ""
 // true

--- a/simulation/modelica/resolveLoops/ElectricalCircuit4.mos
+++ b/simulation/modelica/resolveLoops/ElectricalCircuit4.mos
@@ -6,7 +6,8 @@
 loadModel(Modelica, {"3.2.1"}); getErrorString();
 
 loadFile("ElectricalCircuit4.mo"); getErrorString();
-setDebugFlags("resolveLoops,backenddaeinfo,stateselection"); getErrorString();
+setDebugFlags("backenddaeinfo,stateselection"); getErrorString();
+setCommandLineOptions("--preOptModules+=resolveLoops"); getErrorString();
 simulate(ElectricalCircuit4); getErrorString();
 res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit4_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/resolveLoops/ElectricalCircuit4.mat",
@@ -24,6 +25,8 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit4_res.m
    "C5.i",
    "C6.i"});
 // Result:
+// true
+// ""
 // true
 // ""
 // true

--- a/simulation/modelica/resolveLoops/ElectricalCircuit5.mos
+++ b/simulation/modelica/resolveLoops/ElectricalCircuit5.mos
@@ -6,7 +6,8 @@
 loadModel(Modelica, {"3.2.1"}); getErrorString();
 
 loadFile("ElectricalCircuit5.mo"); getErrorString();
-setDebugFlags("backenddaeinfo,resolveLoops,stateselection"); getErrorString();
+setDebugFlags("backenddaeinfo,stateselection"); getErrorString();
+setCommandLineOptions("--preOptModules+=resolveLoops"); getErrorString();
 simulate(ElectricalCircuit5); getErrorString();
 res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit5_res.mat",
   getEnvironmentVar("REFERENCEFILES")+"/resolveLoops/ElectricalCircuit5.mat",
@@ -21,6 +22,8 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit5_res.m
    "R.i"});
    
 // Result:
+// true
+// ""
 // true
 // ""
 // true

--- a/simulation/modelica/resolveLoops/ElectricalCircuit6.mos
+++ b/simulation/modelica/resolveLoops/ElectricalCircuit6.mos
@@ -6,7 +6,8 @@
 loadModel(Modelica, {"3.2.1"}); getErrorString();
 
 loadFile("ElectricalCircuit6.mo"); getErrorString();
-setDebugFlags("backenddaeinfo,resolveLoops,stateselection"); getErrorString();
+setDebugFlags("backenddaeinfo,stateselection"); getErrorString();
+setCommandLineOptions("--preOptModules+=resolveLoops"); getErrorString();
 simulate(ElectricalCircuit6); getErrorString();
 
 res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit6_res.mat",
@@ -15,6 +16,8 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit6_res.m
   {"c4.v",
   "c1.v"});
 // Result:
+// true
+// ""
 // true
 // ""
 // true

--- a/simulation/modelica/tearing/Tearing3-cel.mos
+++ b/simulation/modelica/tearing/Tearing3-cel.mos
@@ -6,9 +6,9 @@
 
 loadFile("Tearing3.mo"); getErrorString();
 
-setDebugFlags("backenddaeinfo,disableComSubExp"); getErrorString();
+setDebugFlags("backenddaeinfo"); getErrorString();
 setTearingMethod("cellier"); getErrorString();
-setCommandLineOptions("+tearingHeuristic=MC1"); getErrorString();
+setCommandLineOptions("+tearingHeuristic=MC1 --preOptModules-=comSubExp"); getErrorString();
 simulate(Tearing3); getErrorString();
 
 val(u0,0.0); getErrorString();

--- a/simulation/modelica/tearing/Tearing3-celMC3.mos
+++ b/simulation/modelica/tearing/Tearing3-celMC3.mos
@@ -6,9 +6,9 @@
 
 loadFile("Tearing3.mo"); getErrorString();
 
-setDebugFlags("backenddaeinfo,disableComSubExp"); getErrorString();
+setDebugFlags("backenddaeinfo"); getErrorString();
 setTearingMethod("cellier"); getErrorString();
-setCommandLineOptions("+tearingHeuristic=MC3"); getErrorString();
+setCommandLineOptions("+tearingHeuristic=MC3 --preOptModules-=comSubExp"); getErrorString();
 simulate(Tearing3); getErrorString();
 
 val(u0,0.0); getErrorString();

--- a/simulation/modelica/tearing/Tearing3-omc.mos
+++ b/simulation/modelica/tearing/Tearing3-omc.mos
@@ -6,8 +6,9 @@
 
 loadFile("Tearing3.mo"); getErrorString();
 
-setDebugFlags("backenddaeinfo,disableComSubExp"); getErrorString();
+setDebugFlags("backenddaeinfo"); getErrorString();
 setTearingMethod("omcTearing"); getErrorString();
+setCommandLineOptions("--preOptModules-=comSubExp"); getErrorString();
 simulate(Tearing3); getErrorString();
 
 val(u0,0.0); getErrorString();
@@ -22,6 +23,8 @@ val(iL,0.0); getErrorString();
 val(iC,0.0); getErrorString();
 
 // Result:
+// true
+// ""
 // true
 // ""
 // true

--- a/simulation/modelica/tearing/Tearing8-celMC3sorted.mos
+++ b/simulation/modelica/tearing/Tearing8-celMC3sorted.mos
@@ -9,7 +9,7 @@ loadFile("Tearing8.mo"); getErrorString();
 
 setDebugFlags("backenddaeinfo"); getErrorString();
 setTearingMethod("cellier"); getErrorString();
-setCommandLineOptions("+tearingHeuristic=MC3 +d=sortEqnsAndVars"); getErrorString();
+setCommandLineOptions("+tearingHeuristic=MC3 --preOptModules+=sortEqnsVars"); getErrorString();
 simulate(Tearing8); getErrorString();
 
 val(R1.i,0.2); getErrorString();


### PR DESCRIPTION
Use `--preOptModules-=clockPartitioning` instead of `--d=disablePartitioning`.
Use `--preOptModules-=comSubExp` instead of `--d=disableComSubExp`.
Use `--preOptModules+=evalFunc` instead of `--d=evalConstFuncs`.
Use `--preOptModules+=evaluateAllParameters` instead of `--d=evalAllParams`.
Use `--preOptModules+=resolveLoops` instead of `--d=resolveLoops`.
Use `--preOptModules+=sortEqnsVars` instead of `--d=sortEqnsAndVars`.

see OpenModelica/OMCompiler#322