### PR TITLE
Add `-d=noevalfunc` for slow test in PR #462

### DIFF
--- a/openmodelica/bootstrapping/UtilTest.mos
+++ b/openmodelica/bootstrapping/UtilTest.mos
@@ -2,7 +2,7 @@
 // status: correct
 // teardown_command: rm -f Util_* UtilTest_*
 
-setCommandLineOptions("+g=MetaModelica +n=1");
+setCommandLineOptions("-g=MetaModelica -n=1");
 echo(false);
 prefixPath := "../../../OMCompiler/Compiler/Util/";
 echo(true);
@@ -17,8 +17,9 @@ loadFiles({
   "UtilTest.mo"
 });
 getErrorString();
-setCommandLineOptions("+d=rml");
+setCommandLineOptions("-d=rml,noevalfunc");
 listLength(List.intRange2(1, 22000));
+setCommandLineOptions("-d=evalfunc");
 getErrorString();
 List.intRange2(1, 10);
 getErrorString();
@@ -79,6 +80,7 @@ getErrorString();
 // ""
 // true
 // 22000
+// true
 // ""
 // {1,2,3,4,5,6,7,8,9,10}
 // ""


### PR DESCRIPTION
The function interpreter is very slow for large loops compared to list
comprehensions. So disable it for the very large loop. We anyway never
use function interpretation for bootstrapping.