### PR TITLE
Re-enable FMI 2.0 crane test

### DIFF
--- a/openmodelica/cppruntime/fmu/modelExchange/2.0/Crane_FMU2_CPP.mos
+++ b/openmodelica/cppruntime/fmu/modelExchange/2.0/Crane_FMU2_CPP.mos
@@ -24,7 +24,7 @@ val(prismatic_v, 1);
 // ""
 // true
 // ""
-// "SimCode: The model cranes.crane has been translated to FMU"
+// "cranes.crane.fmu"
 // ""
 // "cranes_crane_me_FMU.mo"
 // ""
@@ -36,6 +36,6 @@ val(prismatic_v, 1);
 //     messages = ""
 // end SimulationResult;
 // ""
-// 0.949354567086967
-// 0.3948242611172861
+// 0.9493545671702082
+// 0.394824265705273
 // endResult

--- a/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
+++ b/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
@@ -3,12 +3,12 @@ TEST = ../../../../../rtest -v
 
 TESTFILES = \
 DIC_FMU2_CPP.mos \
+Crane_FMU2_CPP.mos \
 testFMU2MatrixIO.mos \
 testModelDescription.mos \
 testDrumBoiler.mos
 
 FAILINGTESTFILES = \
-Crane_FMU2_CPP.mos \
 CoupledClutches_FMU2_CPP.mos
 
 DEPENDENCIES = \


### PR DESCRIPTION
It had been disabled in October 2016 due to errors on Hudson:
8fc919db6ece27c4031428d2dd2609e53ac8f25f