### PR TITLE
Switch to C run-time for two tests

### DIFF
--- a/simulation/modelica/statemachines/DeadEnd.mos
+++ b/simulation/modelica/statemachines/DeadEnd.mos
@@ -5,7 +5,7 @@
 
 loadFile("DeadEnd.mo");
 echo(false);
-setCommandLineOptions("--simCodeTarget=Cpp"); getErrorString();
+//setCommandLineOptions("--simCodeTarget=Cpp"); getErrorString();
 simulate(DeadEnd, startTime=0, stopTime=2, numberOfIntervals=0); getErrorString();
 echo(true);
 val(state1.active,2);

--- a/simulation/modelica/statemachines/MLS33_17_3_7NA.mos
+++ b/simulation/modelica/statemachines/MLS33_17_3_7NA.mos
@@ -5,7 +5,7 @@
 
 loadFile("MLS33_17_3_7NA.mo");
 echo(false);
-setCommandLineOptions("--simCodeTarget=Cpp"); getErrorString();
+//setCommandLineOptions("--simCodeTarget=Cpp"); getErrorString();
 simulate(MLS33_17_3_7NA, startTime=0, stopTime=30, numberOfIntervals=0); getErrorString();
 echo(true);
 val(v,30.0);


### PR DESCRIPTION
Test-cases DeadEnd.mos and MLS33_17_3_7NA.mos now work
with C run-time, too. Hence, changed tests to use C run-time.