### PR TITLE
Use new flag -d=oldFrontEndUnitCheck

### DIFF
--- a/openmodelica/bootstrapping/LoadCompilerSources.mos
+++ b/openmodelica/bootstrapping/LoadCompilerSources.mos
@@ -278,6 +278,7 @@ if true then /* Suppress output */
     prefixPath + "Util/Settings.mo",
     prefixPath + "Util/SimulationResults.mo",
     prefixPath + "Util/Socket.mo",
+    prefixPath + "Util/StackOverflow.mo",
     prefixPath + "Util/StringUtil.mo",
     prefixPath + "Util/System.mo",
     prefixPath + "Util/TaskGraphResults.mo",

--- a/simulation/modelica/NFunitcheck/UnitCheck1.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck1.mos
@@ -38,7 +38,7 @@ package unitCheckTests
  end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits"); 
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits"); 
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck1);
 getErrorString();

--- a/simulation/modelica/NFunitcheck/UnitCheck10.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck10.mos
@@ -16,7 +16,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits"); 
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits"); 
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck10); getErrorString();
 

--- a/simulation/modelica/NFunitcheck/UnitCheck11.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck11.mos
@@ -16,7 +16,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits"); 
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits"); 
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck11); getErrorString();
 

--- a/simulation/modelica/NFunitcheck/UnitCheck12.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck12.mos
@@ -16,7 +16,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits"); 
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits"); 
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck12); getErrorString();
 

--- a/simulation/modelica/NFunitcheck/UnitCheck13.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck13.mos
@@ -16,7 +16,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits"); getErrorString();
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits"); getErrorString();
 instantiateModel(unitCheckTests.UnitCheck13); getErrorString();
 
 

--- a/simulation/modelica/NFunitcheck/UnitCheck14.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck14.mos
@@ -15,7 +15,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits"); getErrorString();
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits"); getErrorString();
 instantiateModel(unitCheckTests.UnitCheck14); getErrorString();
 
 

--- a/simulation/modelica/NFunitcheck/UnitCheck15.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck15.mos
@@ -21,7 +21,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits"); getErrorString();
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits"); getErrorString();
 instantiateModel(unitCheckTests.UnitCheck15); getErrorString();
 
 

--- a/simulation/modelica/NFunitcheck/UnitCheck16.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck16.mos
@@ -10,7 +10,7 @@ equation
 end test;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits");
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits");
 getErrorString(); 
 instantiateModel(test);
 getErrorString();

--- a/simulation/modelica/NFunitcheck/UnitCheck17.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck17.mos
@@ -19,7 +19,7 @@ package unitCheckTests
   end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits"); 
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits"); 
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck17);
 getErrorString();

--- a/simulation/modelica/NFunitcheck/UnitCheck2.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck2.mos
@@ -16,7 +16,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits");
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits");
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck2); 
 getErrorString();

--- a/simulation/modelica/NFunitcheck/UnitCheck3.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck3.mos
@@ -16,7 +16,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits");
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits");
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck3); getErrorString();
 

--- a/simulation/modelica/NFunitcheck/UnitCheck4.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck4.mos
@@ -16,7 +16,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits");
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits");
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck4); getErrorString();
 

--- a/simulation/modelica/NFunitcheck/UnitCheck5.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck5.mos
@@ -16,7 +16,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits");
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits");
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck5); getErrorString();
 

--- a/simulation/modelica/NFunitcheck/UnitCheck6.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck6.mos
@@ -16,7 +16,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits");
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits");
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck6); getErrorString();
 

--- a/simulation/modelica/NFunitcheck/UnitCheck7.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck7.mos
@@ -16,7 +16,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits");
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits");
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck7); getErrorString();
 

--- a/simulation/modelica/NFunitcheck/UnitCheck8.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck8.mos
@@ -16,7 +16,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits");
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits");
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck8); getErrorString();
 

--- a/simulation/modelica/NFunitcheck/UnitCheck9.mos
+++ b/simulation/modelica/NFunitcheck/UnitCheck9.mos
@@ -18,7 +18,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits");
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits");
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck9); getErrorString();
 

--- a/simulation/modelica/NFunitcheck/Unitcheck18.mos
+++ b/simulation/modelica/NFunitcheck/Unitcheck18.mos
@@ -28,7 +28,7 @@ package unitCheckTests
   end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits"); 
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits"); 
 getErrorString();
 instantiateModel(unitCheckTests.UnitCheck18);
 getErrorString();

--- a/simulation/modelica/NFunitcheck/ticket3631.mos
+++ b/simulation/modelica/NFunitcheck/ticket3631.mos
@@ -13,7 +13,7 @@ package unitCheckTests
 end unitCheckTests;
 "); getErrorString();
 
-setCommandLineOptions("+d=frontEndUnitCheck +d=dumpUnits");
+setCommandLineOptions("-d=oldFrontEndUnitCheck,dumpUnits");
 getErrorString();
 instantiateModel(unitCheckTests.ticket3631); getErrorString();
 


### PR DESCRIPTION
The "NF" unit checking tests use the old frontend for unit checking,
which is wrong.