### PR TITLE
Disable the OutOfMemory test

### DIFF
--- a/flattening/modelica/algorithms-functions/Makefile
+++ b/flattening/modelica/algorithms-functions/Makefile
@@ -89,7 +89,6 @@ LogCall1.mo \
 modelica_1_1_Function10.mo \
 MRFcall.mo \
 MultFuncCall.mo \
-OutOfMemory.mos \
 RecursiveCallExtends.mo \
 RecursiveFunctionCall.mo \
 StackOverflowTest.mos \
@@ -130,6 +129,7 @@ Inline3.mo \
 Inline4.mo \
 Inline5.mo \
 Inline6.mo \
+OutOfMemory.mos \
 StatementCall.mo \
 Vectorizable2.mo
 


### PR DESCRIPTION
It fails too often on Hudson, and the error seems to be due to a bad
longjmp which is really annoying to debug.