### PR TITLE
Disable crane C++ FMU test

### DIFF
--- a/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
+++ b/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
@@ -3,7 +3,6 @@ TEST = ../../../../../rtest -v
 
 TESTFILES = \
 DIC_FMU2_CPP.mos \
-Crane_FMU2_CPP.mos \
 testFMU2MatrixIO.mos \
 testModelDescription.mos \
 testClockDescription.mos \
@@ -11,6 +10,7 @@ testCSTR.mos \
 testDrumBoiler.mos
 
 FAILINGTESTFILES = \
+Crane_FMU2_CPP.mos \
 CoupledClutches_FMU2_CPP.mos
 
 DEPENDENCIES = \


### PR DESCRIPTION
The test fails randomly, even when running the exact same docker image on
the same machine, which suggests the error in not totally reliant on the
CPU architecture used, but perhaps also system load.

```
At t = 0 and h = 1e-24, the corrector convergence test failed repeatedly
or with |h| = hmin.
```

@rfranke failures include https://test.openmodelica.org/jenkins/blue/organizations/jenkins/OpenModelica/detail/master/91/pipeline/112 (which ran on asap.openmodelica.org, which succeeded on the run before and failed on run 88 as well)