### PR TITLE
Use `chmod a-w` instead of `-w`

### DIFF
--- a/openmodelica/interactive-API/Rename.mos
+++ b/openmodelica/interactive-API/Rename.mos
@@ -1,7 +1,7 @@
 // name:      Rename
 // keywords:  rename Component
 // status:    correct
-// setup_command: chmod -w RenameRO.mo
+// setup_command: chmod a-w RenameRO.mo
 //
 loadFile("Rename.mo"); getErrorString();
 


### PR DESCRIPTION
Some versions of chmod give warnings that not all permissions are
changed if you use `-w`, because bits that are set in the umask are not
affected.